### PR TITLE
Add autobuild workflow

### DIFF
--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -1,0 +1,72 @@
+name: CEE AutoBuild
+
+on:
+  push:
+    branches: [ "1.21.1" ]
+  pull_request:
+    branches: [ "1.21.1" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
+
+    - name: Make gradlew executable
+      run: chmod +x ./gradlew
+
+    - name: Build with Gradle Wrapper
+      run: ./gradlew build
+
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: Package
+        path: build/libs
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: write
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Create tag for release
+      run: |
+        git config user.name "github-actions"
+        git config user.email "github-actions@github.com"
+        git tag autobuild-${{ github.run_number }}
+        git push origin autobuild-${{ github.run_number }}
+
+    - name: Download build artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: Package
+        path: build/libs
+
+    - name: Create GitHub Release
+      uses: softprops/action-gh-release@v1
+      with:
+        tag_name: autobuild-${{ github.run_number }}
+        name: Auto Release ${{ github.run_number }}
+        body: |
+          These builds are auto generated on every commit. There is no guarantee these will be stable.
+        draft: false
+        prerelease: true
+        files: build/libs/*.jar
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Would be useful so people can be able to test the newest features and you don't have to constantly send jars in the discord, the link to the releases page can just be pinned