### PR TITLE
Extend max pantograph distance by about a block

### DIFF
--- a/src/main/java/com/george_vi/electroenergetics/content/railway_electrification/catenary/CatenaryHandler.java
+++ b/src/main/java/com/george_vi/electroenergetics/content/railway_electrification/catenary/CatenaryHandler.java
@@ -93,7 +93,7 @@ public class CatenaryHandler {
                         distance = VecHelper.rotate(distance, yaw + 180, Direction.Axis.Y);
                         distance = VecHelper.rotate(distance, -pitch, Direction.Axis.X);
 
-                        if (!(Math.abs(distance.z()) > 2) && !(Math.abs(distance.x()) > 0.5) && !(Math.abs(distance.y()) > 1)) {
+                        if (!(Math.abs(distance.z()) > 2) && !(Math.abs(distance.x()) > 0.5) && !(Math.abs(distance.y()) > 1.75)) {
                             catenaryConnections.computeIfAbsent(train, k -> new ArrayList<>());
                             catenaryConnections.get(train).add(Pair.of((float) t, connection));
                             cutConnections.compute(connection, (k, v) -> v == null ? 1 : v + 1);

--- a/src/main/java/com/george_vi/electroenergetics/content/railway_electrification/pantograph/PantographMovementBehaviour.java
+++ b/src/main/java/com/george_vi/electroenergetics/content/railway_electrification/pantograph/PantographMovementBehaviour.java
@@ -91,7 +91,7 @@ public class PantographMovementBehaviour implements MovementBehaviour {
                 Vec3 distance = pantographPos.subtract(closest);
                 context.rotation.apply(distance).multiply(0, 0, 0);
 
-                if (!(Math.abs(distance.z()) > 1.5) && !(Math.abs(distance.x()) > 0.5) && !(Math.abs(distance.y()) > 1)) {
+                if (!(Math.abs(distance.z()) > 1.5) && !(Math.abs(distance.x()) > 0.5) && !(Math.abs(distance.y()) > 1.75)) {
                     connectionPoint = closest;
                     break;
                 }
@@ -100,7 +100,7 @@ public class PantographMovementBehaviour implements MovementBehaviour {
             if (connectionPoint != null) {
 //                context.world.addParticle(ParticleTypes.ELECTRIC_SPARK, connectionPoint.x, connectionPoint.y, connectionPoint.z, 0, 0, 0);
                 float lo = 0;
-                float hi = 1.3f;
+                float hi = 2f;
                 for (int i = 0; i < 20; i++) {
                     float m1 = lo + (hi - lo) / 3;
                     float m2 = hi - (hi - lo) / 3;


### PR DESCRIPTION
Allows trains of different heights to run on the same line easily and also makes them more comparable to pantographs and wires pantographs.

Before:
Max extension ~1.5 from pantograph
Max extension ~4.5 from ground
<img width="1210" height="1004" alt="image" src="https://github.com/user-attachments/assets/8c4ae192-d9ae-4f44-9166-cb453945489b" />
<img width="1105" height="767" alt="image" src="https://github.com/user-attachments/assets/246f43e4-1732-4320-8c95-80ca1338d929" />

After:
Max extension ~2.25 from pantograph
Max extension ~5.25 from ground
<img width="916" height="837" alt="image" src="https://github.com/user-attachments/assets/1e763e50-91c1-4165-8974-9bd89cf7a4ba" />
<img width="1060" height="830" alt="image" src="https://github.com/user-attachments/assets/98caf88e-73c7-43d3-8ff9-f10cf717845c" />

For reference pantographs and wires can reach ~ 3.5 from pantograph and ~6.5 from ground

This can help if players switch mods or are considering switching cuz it will mean less moving wire heights and stuff will be needed.
And also allows short trains on tall train lines without a booster blocks so they can then run on short wire height lines