### PR TITLE
Fix NPE that causes crashes in pantograph spark handling when pos is …

### DIFF
--- a/src/main/java/com/george_vi/electroenergetics/content/railway_electrification/CatenaryHandler.java
+++ b/src/main/java/com/george_vi/electroenergetics/content/railway_electrification/CatenaryHandler.java
@@ -264,6 +264,9 @@ public class CatenaryHandler {
                 Integer carriageID = ce.getKey();
                 Vec3 pos = ce.getValue();
 
+                if (pos == null)
+                    continue;
+
                 CatnipServices.NETWORK.sendToClientsAround(event.level, pos,
                         100, new UpdateElectricTrainSoundPacket(train.id, carriageID, (float) trainSpeed, acceleration, active, CEERegistries.ELECTRIC_TRAIN_SOUND_TYPE.getId(trainExtension.getSoundType())));
             }


### PR DESCRIPTION
Driving a train that has a pantograph through a Nether portal caused the server to crash due to a NPE when pos is null.