### PR TITLE
Add voltmeter and ammeter gauges to trains

### DIFF
--- a/src/main/java/com/george_vi/electroenergetics/CEEBlocks.java
+++ b/src/main/java/com/george_vi/electroenergetics/CEEBlocks.java
@@ -23,6 +23,7 @@ import com.george_vi.electroenergetics.content.energy_meter.TriPolarEnergyMeterB
 import com.george_vi.electroenergetics.content.fuse.FuseBlock;
 import com.george_vi.electroenergetics.content.fuse.FuseHolderBlock;
 import com.george_vi.electroenergetics.content.gauge.ElectricGaugeBlock;
+import com.george_vi.electroenergetics.content.gauge.ElectricGaugeMovementBehaviour;
 import com.george_vi.electroenergetics.content.ground_rod.GroundRodBlock;
 import com.george_vi.electroenergetics.content.indicator_bulb.IndicatorBulbBlock;
 import com.george_vi.electroenergetics.content.indicator_bulb.IndicatorBulbBlockItem;
@@ -373,7 +374,9 @@ public class CEEBlocks {
             .properties(p -> p.mapColor(MapColor.COLOR_BLACK))
             .blockstate(new GaugeGenerator()::generate)
             .transform(pickaxeOnly())
+            .onRegister(movementBehaviour(new ElectricGaugeMovementBehaviour(false)))
             .item()
+            .tag(AllTags.AllItemTags.CONTRAPTION_CONTROLLED.tag)
             .onRegister(i -> ElectricStatsTooltipModifier.ALL_ENTRIES.register(i, new ElectricStatsTooltipModifier.ElectricStatSet()
                     .addMaxCurrent(CEEConfigs.server().voltageValues.maxAmmeterCurrent::get)))
             .transform(ModelGen.customItemModel("gauge", "_", "item"))
@@ -384,7 +387,9 @@ public class CEEBlocks {
             .properties(p -> p.mapColor(MapColor.COLOR_BLACK))
             .blockstate(new GaugeGenerator()::generate)
             .transform(pickaxeOnly())
+            .onRegister(movementBehaviour(new ElectricGaugeMovementBehaviour(true)))
             .item()
+            .tag(AllTags.AllItemTags.CONTRAPTION_CONTROLLED.tag)
             .onRegister(i -> ElectricStatsTooltipModifier.ALL_ENTRIES.register(i, new ElectricStatsTooltipModifier.ElectricStatSet()
                     .addMaxVoltage(CEEConfigs.server().voltageValues.maxVoltmeterVoltage::get)))
             .transform(ModelGen.customItemModel("gauge", "_", "item"))

--- a/src/main/java/com/george_vi/electroenergetics/CEEPackets.java
+++ b/src/main/java/com/george_vi/electroenergetics/CEEPackets.java
@@ -1,6 +1,7 @@
 package com.george_vi.electroenergetics;
 
 import com.george_vi.electroenergetics.content.energy_meter.ChangeEnergyMeterStatePacket;
+import com.george_vi.electroenergetics.content.railway_electrification.gauges.SyncTrainGaugeDataPacket;
 import com.george_vi.electroenergetics.content.railway_electrification.catenary.ClearCatenaryPacket;
 import com.george_vi.electroenergetics.content.railway_electrification.catenary.SendCatenaryPacket;
 import com.george_vi.electroenergetics.content.railway_electrification.sound_effects.ChangeTrainSoundTypePacket;
@@ -33,6 +34,7 @@ public enum CEEPackets implements BasePacketPayload.PacketTypeProvider {
     SEND_POSITIONED_WIRE_PARTICLE(SendPositionedWireParticlesPacket.class, SendPositionedWireParticlesPacket.STREAM_CODEC),
     SEND_QUADRATIC_PARTICLES(SendQuadraticParticlesPacket.class, SendQuadraticParticlesPacket.STREAM_CODEC),
     REQUEST_VOLTAGE_DATA(RequestVoltageDataPacket.class, RequestVoltageDataPacket.STREAM_CODEC),
+    SYNC_TRAIN_GAUGE_DATA(SyncTrainGaugeDataPacket.class, SyncTrainGaugeDataPacket.STREAM_CODEC),
     ;
 
     private final CatnipPacketRegistry.PacketType<?> type;

--- a/src/main/java/com/george_vi/electroenergetics/config/CVoltages.java
+++ b/src/main/java/com/george_vi/electroenergetics/config/CVoltages.java
@@ -5,6 +5,7 @@ import net.neoforged.neoforge.common.ModConfigSpec;
 
 public class CVoltages extends ConfigBase {
     public final ConfigInt trainMinVoltage = i(1900, 0, "trainMinVoltage", "[in Volts]");
+    public final ConfigInt trainMaxVoltage = i(5000, 0, "trainMaxVoltage", "[in Volts]");
     public final ConfigDouble wireMaxVoltage = d(1500, 0, "wireMaxVoltage", "[in Volts]");
     public final ConfigDouble heavilyInsulatedWireMaxVoltage = d(20_000, 0, "heavilyInsulatedWireMaxVoltage", "[in Volts]");
     public final ConfigDouble highVoltageCapacitorVoltage = d(25_000, 0, "highVoltageCapacitorVoltage", "[in Volts]");

--- a/src/main/java/com/george_vi/electroenergetics/content/gauge/ElectricGaugeMovementBehaviour.java
+++ b/src/main/java/com/george_vi/electroenergetics/content/gauge/ElectricGaugeMovementBehaviour.java
@@ -1,0 +1,206 @@
+package com.george_vi.electroenergetics.content.gauge;
+
+import com.george_vi.electroenergetics.config.CEEConfigs;
+import com.george_vi.electroenergetics.content.railway_electrification.ElectricTrainData;
+import com.george_vi.electroenergetics.content.railway_electrification.gauges.ClientTrainGaugeData;
+import com.george_vi.electroenergetics.mixin_interfaces.ICEETrainExtension;
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.simibubi.create.AllPartialModels;
+import com.simibubi.create.api.behaviour.movement.MovementBehaviour;
+import com.simibubi.create.content.contraptions.behaviour.MovementContext;
+import com.simibubi.create.content.contraptions.render.ContraptionMatrices;
+import com.simibubi.create.content.kinetics.gauge.GaugeBlock;
+import com.simibubi.create.content.trains.entity.CarriageContraptionEntity;
+import com.simibubi.create.foundation.virtualWorld.VirtualRenderWorld;
+import dev.engine_room.flywheel.lib.model.baked.PartialModel;
+import net.createmod.catnip.animation.AnimationTickHolder;
+import net.createmod.catnip.data.Iterate;
+import net.createmod.catnip.render.CachedBuffers;
+import net.minecraft.client.renderer.LevelRenderer;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.core.Direction;
+import net.minecraft.util.Mth;
+import net.minecraft.world.level.block.state.BlockState;
+
+/**
+ * Movement behaviour for electric gauges (voltmeters and ammeters) on train contraptions.
+ * Reads voltage and current data from the train and displays it on the gauge dial.
+ */
+public class ElectricGaugeMovementBehaviour implements MovementBehaviour {
+    private static final float DIAL_SMOOTHING_FACTOR = 0.25f;
+
+    private final boolean voltmeter;
+
+    public ElectricGaugeMovementBehaviour(boolean voltmeter) {
+        this.voltmeter = voltmeter;
+    }
+
+    @Override
+    public void tick(MovementContext context) {
+        double voltage = 0;
+        double current = 0;
+
+        if (context.contraption.entity instanceof CarriageContraptionEntity carriageEntity) {
+            // Get train ID and look up values in cache
+            var carriage = carriageEntity.getCarriage();
+            if (carriage == null || carriage.train == null)
+                return;
+
+            java.util.UUID trainId = carriage.train.id;
+
+            if (context.world.isClientSide()) {
+                // On client, read from synced cache
+                ClientTrainGaugeData.TrainGaugeValues values =
+                    ClientTrainGaugeData.get(trainId);
+                voltage = values.voltage();
+                current = values.current();
+            } else {
+                // On server, read directly from train data
+                if (carriage.train instanceof ICEETrainExtension trainExtension) {
+                    ElectricTrainData trainData = trainExtension.getElectricTrainData();
+                    voltage = trainData.displayVoltage;
+                    current = trainData.displayCurrent;
+                }
+            }
+        }
+
+        // Calculate dial target based on gauge type
+        // (note that this doesn't include accumulators)
+        float dialTarget;
+        if (voltmeter) {
+            // Scale from train minimum voltage to maximum train voltage
+            double minVoltage = CEEConfigs.server().voltageValues.trainMinVoltage.get();
+            double maxVoltage = CEEConfigs.server().voltageValues.trainMaxVoltage.get();
+            dialTarget = (float) Mth.clamp((voltage - minVoltage) / (maxVoltage - minVoltage), 0, 1);
+        } else {
+            // Scale from 0 to maximum theoretical current
+            // Max current = Max voltage / Min resistance
+            double maxVoltage = CEEConfigs.server().voltageValues.trainMaxVoltage.get();
+            double minResistance = Math.min(
+                CEEConfigs.server().resistanceValues.electricTrainAccelerationResistance.get(),
+                CEEConfigs.server().resistanceValues.electricTrainCruiseResistance.get()
+            );
+            double maxCurrent = maxVoltage / minResistance;
+            dialTarget = (float) Mth.clamp(current / maxCurrent, 0, 1);
+        }
+
+        boolean firstTick = !context.data.contains("Initialized");
+
+        // Get previous frame's state for interpolation
+        float prevDialState = firstTick ? dialTarget : context.data.getFloat("DialState");
+        float currentDialState;
+
+        if (firstTick) {
+            // First tick: start at target
+            currentDialState = dialTarget;
+            context.data.putBoolean("Initialized", true);
+        } else {
+            // Normal operation: smooth interpolation toward target
+            currentDialState = prevDialState + (dialTarget - prevDialState) * DIAL_SMOOTHING_FACTOR;
+        }
+
+        // Store updated state for next tick
+        context.data.putFloat("PrevDialState", prevDialState);
+        context.data.putFloat("DialState", currentDialState);
+        context.data.putFloat("DialTarget", dialTarget);
+    }
+
+    @Override
+    public void renderInContraption(MovementContext context, VirtualRenderWorld renderWorld,
+                                     ContraptionMatrices matrices, MultiBufferSource buffer) {
+        PoseStack ms = matrices.getViewProjection();
+        BlockState state = context.state;
+
+        // Interpolate dial state for smooth animation
+        float partialTicks = AnimationTickHolder.getPartialTicks();
+        float progress = Mth.lerp(partialTicks,
+                context.data.getFloat("PrevDialState"),
+                context.data.getFloat("DialState"));
+
+        // Get gauge properties
+        Direction facing = state.getValue(ElectricGaugeBlock.FACING);
+        boolean axisAlongFirst = state.getValue(GaugeBlock.AXIS_ALONG_FIRST_COORDINATE);
+
+        // Determine which model to use
+        PartialModel headModel = voltmeter
+                ? AllPartialModels.GAUGE_HEAD_SPEED
+                : AllPartialModels.GAUGE_HEAD_STRESS;
+
+        int light = LevelRenderer.getLightColor(renderWorld, context.localPos);
+
+        // Render on the correct face
+        for (Direction direction : Iterate.directions) {
+            if (!shouldRenderHeadOnFace(state, facing, axisAlongFirst, direction))
+                continue;
+
+            float dialPivot = 5.75f / 16f;
+            CachedBuffers.partial(AllPartialModels.GAUGE_DIAL, state)
+                    .transform(matrices.getModel())
+                    .rotateCentered((float) ((-direction.toYRot() - 90) / 180 * Math.PI), Direction.UP)
+                    .translate(0, dialPivot, dialPivot)
+                    .rotate((float) (Math.PI / 2 * -progress), Direction.EAST)
+                    .translate(0, -dialPivot, -dialPivot)
+                    .light(light)
+                    .useLevelLight(context.world, matrices.getWorld())
+                    .renderInto(ms, buffer.getBuffer(RenderType.solid()));
+
+            CachedBuffers.partial(headModel, state)
+                    .transform(matrices.getModel())
+                    .rotateCentered((float) ((-direction.toYRot() - 90) / 180 * Math.PI), Direction.UP)
+                    .light(light)
+                    .useLevelLight(context.world, matrices.getWorld())
+                    .renderInto(ms, buffer.getBuffer(RenderType.solid()));
+        }
+    }
+
+    /**
+     * Determines if the gauge head should render on a given face.
+     * Replicates the logic from {@link ElectricGaugeBlock#shouldRenderHeadOnFace}
+     * for use in the movement behaviour.
+     *
+     * @param state The block state of the gauge
+     * @param facing The direction the gauge is facing
+     * @param axisAlongFirst Whether the gauge axis is along the first coordinate
+     * @param face The face being checked for rendering
+     * @return true if the gauge head should render on this face
+     */
+    private static boolean shouldRenderHeadOnFace(BlockState state, Direction facing, boolean axisAlongFirst, Direction face) {
+        if (face.getAxis().isVertical())
+            return false;
+        if (face == facing.getOpposite())
+            return false;
+
+        Direction.Axis gaugeAxis = getAxis(state, facing, axisAlongFirst);
+        if (face.getAxis() == gaugeAxis)
+            return false;
+        if (gaugeAxis == Direction.Axis.Y && face != facing)
+            return false;
+
+        return true;
+    }
+
+    /**
+     * Gets the axis of the gauge based on its state.
+     * Replicates the logic from {@link ElectricGaugeBlock#getAxis} for use in the movement behaviour.
+     *
+     * @param state The block state of the gauge
+     * @param facing The direction the gauge is facing
+     * @param axisAlongFirst Whether the gauge axis is along the first coordinate
+     * @return The axis of the gauge
+     */
+    private static Direction.Axis getAxis(BlockState state, Direction facing, boolean axisAlongFirst) {
+        Direction.Axis pistonAxis = facing.getAxis();
+
+        if (pistonAxis == Direction.Axis.X)
+            return axisAlongFirst ? Direction.Axis.Y : Direction.Axis.Z;
+        if (pistonAxis == Direction.Axis.Y)
+            return axisAlongFirst ? Direction.Axis.X : Direction.Axis.Z;
+        return axisAlongFirst ? Direction.Axis.X : Direction.Axis.Y;
+    }
+
+    @Override
+    public boolean disableBlockEntityRendering() {
+        return true;
+    }
+}

--- a/src/main/java/com/george_vi/electroenergetics/content/railway_electrification/ElectricTrainData.java
+++ b/src/main/java/com/george_vi/electroenergetics/content/railway_electrification/ElectricTrainData.java
@@ -17,4 +17,14 @@ public class ElectricTrainData {
     public AttachedNode trainNode;
     public AttachedNode groundNode;
     public WireSimulationState.WireCutHandle wireCutHandle;
+
+    // Voltage value for display on gauges (voltmeters/ammeters) attached to train contraptions
+    public double displayVoltage = 0;
+    // Total current draw for display on ammeters attached to train contraptions
+    public double displayCurrent = 0;
+
+    // Packet throttling for gauge data sync
+    public double lastSyncedVoltage = 0;
+    public double lastSyncedCurrent = 0;
+    public int ticksSinceGaugeSync = 0;
 }

--- a/src/main/java/com/george_vi/electroenergetics/content/railway_electrification/gauges/ClientTrainGaugeData.java
+++ b/src/main/java/com/george_vi/electroenergetics/content/railway_electrification/gauges/ClientTrainGaugeData.java
@@ -1,0 +1,73 @@
+package com.george_vi.electroenergetics.content.railway_electrification.gauges;
+
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Client-side cache for train voltage and current values.
+ * Used to sync data from server to gauges on train contraptions.
+ * Entries are automatically cleaned up after 5 seconds of no updates.
+ */
+@OnlyIn(Dist.CLIENT)
+public class ClientTrainGaugeData {
+    private static final Map<UUID, CachedTrainData> TRAIN_DATA = new HashMap<>();
+    private static final long EXPIRE_TIME_MS = 5000;
+
+    /**
+     * Updates the cached voltage and current values for a train.
+     * Called when receiving {@link SyncTrainGaugeDataPacket} from the server.
+     *
+     * @param trainId The UUID of the train
+     * @param voltage The train's current voltage in volts
+     * @param current The train's total current draw in amps
+     */
+    public static void update(UUID trainId, double voltage, double current) {
+        TRAIN_DATA.put(trainId, new CachedTrainData(voltage, current, System.currentTimeMillis()));
+    }
+
+    /**
+     * Retrieves the cached voltage and current values for a train.
+     * Returns {@link TrainGaugeValues#ZERO} if no data exists for the given train.
+     *
+     * @param trainId The UUID of the train
+     * @return The cached gauge values, or zero values if not found
+     */
+    public static TrainGaugeValues get(UUID trainId) {
+        CachedTrainData cached = TRAIN_DATA.get(trainId);
+        if (cached == null)
+            return TrainGaugeValues.ZERO;
+        return new TrainGaugeValues(cached.voltage, cached.current);
+    }
+
+    /**
+     * Called periodically to remove stale entries.
+     * Should be called from a client tick event.
+     */
+    public static void tick() {
+        long now = System.currentTimeMillis();
+        Iterator<Map.Entry<UUID, CachedTrainData>> iterator = TRAIN_DATA.entrySet().iterator();
+        while (iterator.hasNext()) {
+            Map.Entry<UUID, CachedTrainData> entry = iterator.next();
+            if (now - entry.getValue().timestamp > EXPIRE_TIME_MS) {
+                iterator.remove();
+            }
+        }
+    }
+
+    /**
+     * Internal cached data with timestamp for expiry tracking.
+     */
+    private record CachedTrainData(double voltage, double current, long timestamp) {}
+
+    /**
+     * Public-facing gauge values without the internal timestamp.
+     */
+    public record TrainGaugeValues(double voltage, double current) {
+        public static final TrainGaugeValues ZERO = new TrainGaugeValues(0, 0);
+    }
+}

--- a/src/main/java/com/george_vi/electroenergetics/content/railway_electrification/gauges/SyncTrainGaugeDataPacket.java
+++ b/src/main/java/com/george_vi/electroenergetics/content/railway_electrification/gauges/SyncTrainGaugeDataPacket.java
@@ -1,0 +1,42 @@
+package com.george_vi.electroenergetics.content.railway_electrification.gauges;
+
+import com.george_vi.electroenergetics.CEEPackets;
+import io.netty.buffer.ByteBuf;
+import net.createmod.catnip.net.base.ClientboundPacketPayload;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
+
+import java.util.UUID;
+
+/**
+ * Packet sent from server to client to sync train voltage and current data for gauge displays.
+ * This allows voltmeters and ammeters on train contraptions to display accurate real-time values.
+ *
+ * @param trainId The UUID of the train
+ * @param voltage The train's current voltage in volts
+ * @param current The train's total current draw in amps
+ */
+public record SyncTrainGaugeDataPacket(UUID trainId, double voltage, double current) implements ClientboundPacketPayload {
+
+    public static final StreamCodec<ByteBuf, SyncTrainGaugeDataPacket> STREAM_CODEC = StreamCodec.composite(
+            ByteBufCodecs.fromCodec(net.minecraft.core.UUIDUtil.CODEC), SyncTrainGaugeDataPacket::trainId,
+            ByteBufCodecs.DOUBLE, SyncTrainGaugeDataPacket::voltage,
+            ByteBufCodecs.DOUBLE, SyncTrainGaugeDataPacket::current,
+            SyncTrainGaugeDataPacket::new
+    );
+
+    @Override
+    @OnlyIn(Dist.CLIENT)
+    public void handle(LocalPlayer player) {
+        ClientTrainGaugeData.update(trainId, voltage, current);
+    }
+
+    @Override
+    public PacketTypeProvider getTypeProvider() {
+        return CEEPackets.SYNC_TRAIN_GAUGE_DATA;
+    }
+}
+

--- a/src/main/java/com/george_vi/electroenergetics/events/GameEvents.java
+++ b/src/main/java/com/george_vi/electroenergetics/events/GameEvents.java
@@ -8,6 +8,7 @@ import com.george_vi.electroenergetics.client.WireRenderer;
 import com.george_vi.electroenergetics.commands.CEECommands;
 import com.george_vi.electroenergetics.content.bulb.BulbDevice;
 import com.george_vi.electroenergetics.content.converter.ConverterBlockEntity;
+import com.george_vi.electroenergetics.content.railway_electrification.gauges.ClientTrainGaugeData;
 import com.george_vi.electroenergetics.content.railway_electrification.sound_effects.ElectricTrainSounds;
 import com.george_vi.electroenergetics.content.wire.WireSync;
 import com.george_vi.electroenergetics.content.wire.interaction.WireInteractionBehaviour;
@@ -18,7 +19,6 @@ import com.george_vi.electroenergetics.simulation.infrastructure.InfrastructureS
 import com.george_vi.electroenergetics.devices.device.DevicesSavedData;
 import dev.engine_room.flywheel.api.event.ReloadLevelRendererEvent;
 import net.minecraft.client.Minecraft;
-import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
@@ -52,6 +52,7 @@ public class GameEvents {
         WireInteractionHandler.tick();
         WireEffects.tick();
         ElectricTrainSounds.tick();
+        ClientTrainGaugeData.tick();
     }
 
     @OnlyIn(Dist.CLIENT)

--- a/src/main/java/com/george_vi/electroenergetics/simulation/infrastructure/CatenaryModule.java
+++ b/src/main/java/com/george_vi/electroenergetics/simulation/infrastructure/CatenaryModule.java
@@ -3,6 +3,7 @@ package com.george_vi.electroenergetics.simulation.infrastructure;
 import com.george_vi.electroenergetics.CEERegistries;
 import com.george_vi.electroenergetics.config.CEEConfigs;
 import com.george_vi.electroenergetics.content.railway_electrification.ElectricTrainData;
+import com.george_vi.electroenergetics.content.railway_electrification.gauges.SyncTrainGaugeDataPacket;
 import com.george_vi.electroenergetics.content.railway_electrification.pantograph.TrainPantographEntry;
 import com.george_vi.electroenergetics.content.railway_electrification.sound_effects.UpdateElectricTrainSoundPacket;
 import com.george_vi.electroenergetics.foundation.SendSparkPacket;
@@ -14,6 +15,7 @@ import com.george_vi.electroenergetics.simulation.SimulationResults;
 import com.george_vi.electroenergetics.simulation.electrical_properties.ElectricalProperties;
 import com.simibubi.create.Create;
 import com.simibubi.create.content.trains.entity.Carriage;
+import com.simibubi.create.content.trains.entity.CarriageContraptionEntity;
 import com.simibubi.create.content.trains.entity.Train;
 import net.createmod.catnip.math.VecHelper;
 import net.createmod.catnip.platform.CatnipServices;
@@ -26,6 +28,8 @@ import net.minecraft.world.phys.Vec3;
 import java.util.*;
 
 public class CatenaryModule {
+    private static final double GAUGE_SYNC_THRESHOLD = 0.05; // 5% change threshold for network sync
+
     final InfrastructureSavedData sd;
     final ServerLevel level;
     final WireSimulationState wireSimulationState;
@@ -138,13 +142,24 @@ public class CatenaryModule {
             double trainSpeed = Math.abs(train.speed);
             float acceleration = (float) (trainSpeed - trainData.lastSpeed);
 
+            // This needs to happen in this method as the train speed is updated after it.
+            trainData.lastSpeed = trainSpeed;
+
             AttachedNode groundNode = trainData.groundNode = new AttachedNode(id, "CEEPantographGroundNode");
             AttachedNode trainNode = trainData.trainNode = new AttachedNode(id, "CEETrainNode");
             builder.addNode(groundNode);
             builder.addNode(trainNode);
             builder.ground(groundNode, 10);
-            double trainResistance = Math.abs(train.speed) > 0.01 ?
-                    acceleration > 0.001 ? CEEConfigs.server().resistanceValues.electricTrainAccelerationResistance.get() : CEEConfigs.server().resistanceValues.electricTrainCruiseResistance.get() : 9999;
+
+            double trainResistance;
+            if (Math.abs(train.speed) > 0.01) {
+                trainResistance = acceleration > 0.001
+                        ? CEEConfigs.server().resistanceValues.electricTrainAccelerationResistance.get()
+                        : CEEConfigs.server().resistanceValues.electricTrainCruiseResistance.get();
+            } else {
+                trainResistance = 9999;
+            }
+
             if (trainData.accumulatorCharge < trainData.accumulators)
                 trainResistance = 1 / (1 / CEEConfigs.server().resistanceValues.electricTrainAccelerationResistance.get() + 1 / trainResistance);
             builder.connect(groundNode, trainNode, ElectricalProperties.resistor(trainResistance));
@@ -179,19 +194,57 @@ public class CatenaryModule {
                 voltage = Math.abs(results.getVoltageAt(groundNode, trainNode));
             else
                 voltage = 0;
+
+            // Store voltage for gauge displays on train contraptions
+            trainData.displayVoltage = voltage;
+
             boolean active = trainData.hasCreativeSource || voltage > CEEConfigs.server().voltageValues.trainMinVoltage.get();
             double trainSpeed = train.derailed ? 0 : Math.abs(train.speed);
+
+            // Calculate total current draw for ammeter displays
+            double totalCurrent = 0;
 
             // Sparks
             for (TrainPantographEntry pantograph : trainData.pantographs) {
                 if (pantograph.node == null || trainNode == null)
                     continue;
                 double current = Math.abs(results.getCurrentThrough(trainNode, pantograph.node));
+                totalCurrent += current;
+
                 Vec3 sparkPos = pantographSparkPosition(level, train, pantograph, current);
                 if (sparkPos != null)
                     CatnipServices.NETWORK.sendToClientsAround(level, sparkPos,
                             40, new SendSparkPacket(sparkPos, SendSparkPacket.SparkSize.MEDIUM));
                 pantograph.lastCurrent = current;
+            }
+
+            // Store total current for ammeter displays on train contraptions
+            trainData.displayCurrent = totalCurrent;
+
+            // Sync voltage and current to clients for gauge displays (with throttling to reduce network traffic)
+            // Only send when values change significantly or every 5 ticks minimum
+            trainData.ticksSinceGaugeSync++;
+            boolean significantVoltageChange = Math.abs(voltage - trainData.lastSyncedVoltage) > Math.max(voltage, trainData.lastSyncedVoltage) * GAUGE_SYNC_THRESHOLD;
+            boolean significantCurrentChange = Math.abs(totalCurrent - trainData.lastSyncedCurrent) > Math.max(totalCurrent, trainData.lastSyncedCurrent) * GAUGE_SYNC_THRESHOLD;
+            boolean shouldSync = trainData.ticksSinceGaugeSync >= 5 || significantVoltageChange || significantCurrentChange;
+
+            if (shouldSync && !train.carriages.isEmpty()) {
+                Carriage.DimensionalCarriageEntity firstCarriage = train.carriages.getFirst().getDimensional(level.dimension());
+                if (firstCarriage != null && firstCarriage.entity != null) {
+                    CarriageContraptionEntity entity = firstCarriage.entity.get();
+                    if (entity != null) {
+                        Vec3 trainPos = entity.position();
+                        CatnipServices.NETWORK.sendToClientsAround(
+                            level,
+                            trainPos,
+                            100,
+                            new SyncTrainGaugeDataPacket(train.id, voltage, totalCurrent)
+                        );
+                        trainData.lastSyncedVoltage = voltage;
+                        trainData.lastSyncedCurrent = totalCurrent;
+                        trainData.ticksSinceGaugeSync = 0;
+                    }
+                }
             }
 
             if (!active) {
@@ -218,7 +271,6 @@ public class CatenaryModule {
             }
             float acceleration = (float) (trainSpeed - trainData.lastSpeed);
 
-            trainData.lastSpeed = trainSpeed;
             for (Map.Entry<Integer, Vec3> ce : positions.entrySet()) {
                 Integer carriageID = ce.getKey();
                 Vec3 pos = ce.getValue();


### PR DESCRIPTION
This PR adds support for voltmeters and ammeters on electrified train contraptions. It also adds a new config value for the max train voltage, though currently it's only used for the gauge scale. Additionally, I changed where `lastSpeed`is calculated, as in my testing, speed would always update after `buildCircuit` but before `finishSimulation`, which caused the train to always use the resistance value for cruising.

Some implementation details:
- Voltmeter is scaled [minTrainVoltage, maxTrainVoltage]. This means all voltages which fall below the minimum are shown as zero. I chose this to make the usable range larger.
- Ammeter is scaled [0, maxTrainCurrent]. Max current is calculated based on the max train voltage and minimum train resistance when non-stopped.
- Currently accumulators aren't taken into account (except for charging, since it pulls energy through the pantograph), so the gauges effectively function as "what is being pulled from the pantographs?". This could be confusing, as the train can have 0 voltage but still be powered by accumulators. So alternatively, the gauges could take the accumulators into account and report "what's available to the motors?".


Let me know if there are any issues or changes you'd like me to make.