### PR TITLE
Fix cross-dimensional electric train handling

### DIFF
--- a/src/main/java/com/george_vi/electroenergetics/simulation/infrastructure/CatenaryModule.java
+++ b/src/main/java/com/george_vi/electroenergetics/simulation/infrastructure/CatenaryModule.java
@@ -230,7 +230,7 @@ public class CatenaryModule {
             boolean shouldSync = trainData.ticksSinceGaugeSync >= 5 || significantVoltageChange || significantCurrentChange;
 
             if (shouldSync && !train.carriages.isEmpty()) {
-                Carriage.DimensionalCarriageEntity firstCarriage = train.carriages.getFirst().getDimensional(level.dimension());
+                Carriage.DimensionalCarriageEntity firstCarriage = train.carriages.getFirst().getDimensionalIfPresent(level.dimension());
                 if (firstCarriage != null && firstCarriage.entity != null) {
                     CarriageContraptionEntity entity = firstCarriage.entity.get();
                     if (entity != null) {
@@ -260,7 +260,9 @@ public class CatenaryModule {
             Map<Integer, Vec3> positions = new HashMap<>();
             for (Carriage carriage : train.carriages) {
                 if (((IPantographList)carriage).electroEnergetics$hasElectricMotor()) {
-                    Carriage.DimensionalCarriageEntity dce = carriage.getDimensional(level);
+                    Carriage.DimensionalCarriageEntity dce = carriage.getDimensionalIfPresent(level.dimension());
+                    if (dce == null)
+                        continue;
 
                     int carriageIndex = train.carriages.indexOf(carriage);
                     if (carriage.isOnTwoBogeys()) {


### PR DESCRIPTION
This PR addresses a simple bug that arises when traversing dimensions. It stems from the fact that calling `carriage.getDimensional()` creates an entry in the carriage's dimensional entity map.

For example:
1. The overworld catenary module is being ticked.
2. We arrive at a train that is in the nether.
3. `carriage.getDimensional(level)` is called
4. A dimensional entry for `level` (which corresponds to the overworld) is created in the carriage's map, even though the carriage is entirely in the nether.

This creates an issue when the train attempts to re-enter the overworld via a portal. "A Carriage cannot enter a portal whilst leaving another" message is printed.

This is fixed by calling `getDimensionalIfPresent` instead, which doesn't create a phantom entry if the carriage isn't in the same level as the `CatenaryModule`.