### PR TITLE
Cull wires and catenary effects when in unloaded chunks

### DIFF
--- a/src/main/java/com/george_vi/electroenergetics/client/CatenaryVisual.java
+++ b/src/main/java/com/george_vi/electroenergetics/client/CatenaryVisual.java
@@ -162,8 +162,21 @@ public class CatenaryVisual implements EffectVisual<WireEffect>, LightUpdatedVis
 
         // Clear instances if not loaded
         if (!chunksLoaded) {
-            delete();
+            for (TransformedInstance instance : upperInstances)
+                instance.setVisible(false);
+
+            for (TransformedInstance instance : lowerInstances)
+                instance.setVisible(false);
+
             return;
+        }
+        else
+        {
+            for (TransformedInstance instance : upperInstances)
+                instance.setVisible(true);
+
+            for (TransformedInstance instance : lowerInstances)
+                instance.setVisible(true);
         }
 
         BlockState startingState = level.getBlockState(connection.pos1());

--- a/src/main/java/com/george_vi/electroenergetics/client/CatenaryVisual.java
+++ b/src/main/java/com/george_vi/electroenergetics/client/CatenaryVisual.java
@@ -158,7 +158,7 @@ public class CatenaryVisual implements EffectVisual<WireEffect>, LightUpdatedVis
         float wireWidth = 0.66f;
 
         // Check if chunks are loaded on the client
-        boolean chunksLoaded = level.isLoaded(BlockPos.containing(start)) && level.isLoaded(BlockPos.containing(end));
+        boolean chunksLoaded = level.isLoaded(connection.pos1()) && level.isLoaded(connection.pos2());
 
         // Clear instances if not loaded
         if (!chunksLoaded) {

--- a/src/main/java/com/george_vi/electroenergetics/client/CatenaryVisual.java
+++ b/src/main/java/com/george_vi/electroenergetics/client/CatenaryVisual.java
@@ -150,10 +150,21 @@ public class CatenaryVisual implements EffectVisual<WireEffect>, LightUpdatedVis
     @Override
     public void update(float partialTick) {
         ClientLevel level = Minecraft.getInstance().level;
+        assert level != null;
+
         Vec3 start = Vec3.atBottomCenterOf(connection.pos1().subtract(visualizationContext.renderOrigin()));
         Vec3 end = Vec3.atBottomCenterOf(connection.pos2().subtract(visualizationContext.renderOrigin()));
 
         float wireWidth = 0.66f;
+
+        // Check if chunks are loaded on the client
+        boolean chunksLoaded = level.isLoaded(BlockPos.containing(start)) && level.isLoaded(BlockPos.containing(end));
+
+        // Clear instances if not loaded
+        if (!chunksLoaded) {
+            delete();
+            return;
+        }
 
         BlockState startingState = level.getBlockState(connection.pos1());
         BlockState endingState = level.getBlockState(connection.pos2());

--- a/src/main/java/com/george_vi/electroenergetics/client/WireRenderer.java
+++ b/src/main/java/com/george_vi/electroenergetics/client/WireRenderer.java
@@ -78,7 +78,7 @@ public class WireRenderer {
                 BlockPos pos2 = connection.pos2();
 
                 if (!InWorldNode.isPosFullyLoadable(level, pos1) ||
-                        !InWorldNode.isPosFullyLoadable(level, pos1))
+                        !InWorldNode.isPosFullyLoadable(level, pos2))
                     continue;
                 
                 BlockState startingState = level.getBlockState(pos1);

--- a/src/main/java/com/george_vi/electroenergetics/client/WireVisual.java
+++ b/src/main/java/com/george_vi/electroenergetics/client/WireVisual.java
@@ -89,12 +89,29 @@ public class WireVisual implements EffectVisual<WireEffect>, LightUpdatedVisual,
     @Override
     public void update(float partialTick) {
         ClientLevel level = Minecraft.getInstance().level;
+        assert level != null;
+
         Vec3 pos1 = connection.node1().getPosition(level, partialTick);
         Vec3 pos2 = connection.node2().getPosition(level, partialTick);
 
         if (pos1 == null || pos2 == null) {
             pos1 = connection.node1().sourcePos().getCenter();
             pos2 = connection.node2().sourcePos().getCenter();
+        }
+
+        boolean isFullyLoaded = connection.isFullyLoaded(level);
+
+        // Check if chunks are loaded on the client
+        boolean chunksLoaded = level.isLoaded(BlockPos.containing(pos1)) && level.isLoaded(BlockPos.containing(pos2));
+
+        // Clear instances if not loaded
+        if (!isFullyLoaded || !chunksLoaded) {
+            if (!instances.isEmpty()) {
+                for (TransformedInstance instance : instances)
+                    instance.delete();
+                instances.clear();
+            }
+            return;
         }
 
         pos1 = pos1.subtract(visualizationContext.renderOrigin().getX(), visualizationContext.renderOrigin().getY(), visualizationContext.renderOrigin().getZ());


### PR DESCRIPTION
This PR adds a check for whether a chunk is loaded containing the wires or catenaries. This fixes them rendering outside render distance when Iris is installed. I also fixed a typo in `WireRenderer` that I noticed.