### PR TITLE
Fix insulated wire connectors

### DIFF
--- a/src/main/java/com/george_vi/electroenergetics/client/WireRenderer.java
+++ b/src/main/java/com/george_vi/electroenergetics/client/WireRenderer.java
@@ -249,7 +249,7 @@ public class WireRenderer {
                                         BlockPos.containing(pos1.add(nextPoint).scale(0.5))))
                                 .renderInto(pose, buffer.getBuffer(RenderType.solid()));
 
-                        outerInsulatorJumpers.computeIfAbsent(connection.node2(), (k) -> new ArrayList<>())
+                        outerInsulatorJumpers.computeIfAbsent(connection.node1(), (k) -> new ArrayList<>())
                                 .add(nextPoint);
                     }
 


### PR DESCRIPTION
This PR fixes a minor mistake in wire rendering. Connectors can be wrenched until a variant with an insulator appears. If there are two of these in a row, a small connecting wire appears. However, it connects the wrong spots on the wire:
<img width="2560" height="1371" alt="2026-04-28_17 47 44" src="https://github.com/user-attachments/assets/b53298b4-5712-4ab0-9a85-954eb64cccc4" />

This appears to be caused by `isBlock1Outer` and `isBlock2Outer` both depending on `connection.node2()`. Changing one of them to `connection.node1()` fixes this:
<img width="2560" height="1371" alt="2026-04-28_17 48 49" src="https://github.com/user-attachments/assets/dcd292c6-6101-4171-894a-b9169bf9c58c" />
