### PR TITLE
Fix voltage key misspelling

### DIFF
--- a/src/generated/resources/assets/electroenergetics/lang/en_ud.json
+++ b/src/generated/resources/assets/electroenergetics/lang/en_ud.json
@@ -337,7 +337,7 @@
   "electroenergetics.subtitle.hum": "ɯnH",
   "electroenergetics.subtitle.sulfur_hexafluoride_breaker_trip": "sdıɹ⟘ ɹǝʞɐǝɹᗺ ǝpıɹonןɟɐxǝH ɹnɟןnS",
   "electroenergetics.subtitle.train_relay": "ʎɐןǝᴚ uıɐɹ⟘",
-  "electroenergetics.subtitle.votlage_regulator": "sdǝʇS ɹoʇɐןnbǝᴚ ǝbɐʇןoΛ",
+  "electroenergetics.subtitle.voltage_regulator": "sdǝʇS ɹoʇɐןnbǝᴚ ǝbɐʇןoΛ",
   "electroenergetics.tooltip.energy_meter.energy": "%1$s :ʎbɹǝuƎ ןɐʇo⟘",
   "electroenergetics.tooltip.energy_meter.owner": "%1$s :ɹǝuʍO",
   "electroenergetics.tooltip.max_current": ":ʇuǝɹɹnƆ xɐW",

--- a/src/generated/resources/assets/electroenergetics/lang/en_us.json
+++ b/src/generated/resources/assets/electroenergetics/lang/en_us.json
@@ -337,7 +337,7 @@
   "electroenergetics.subtitle.hum": "Hum",
   "electroenergetics.subtitle.sulfur_hexafluoride_breaker_trip": "Sulfur Hexafluoride Breaker Trips",
   "electroenergetics.subtitle.train_relay": "Train Relay",
-  "electroenergetics.subtitle.votlage_regulator": "Voltage Regulator Steps",
+  "electroenergetics.subtitle.voltage_regulator": "Voltage Regulator Steps",
   "electroenergetics.tooltip.energy_meter.energy": "Total Energy: %1$s",
   "electroenergetics.tooltip.energy_meter.owner": "Owner: %1$s",
   "electroenergetics.tooltip.max_current": "Max Current:",

--- a/src/main/resources/assets/electroenergetics/lang/default.json
+++ b/src/main/resources/assets/electroenergetics/lang/default.json
@@ -105,7 +105,7 @@
   "electroenergetics.subtitle.arcing": "Arcing",
   "electroenergetics.subtitle.electric_train": "Electric Train Sounds",
   "electroenergetics.subtitle.buzzer": "Buzzer Buzzes",
-  "electroenergetics.subtitle.votlage_regulator": "Voltage Regulator Steps",
+  "electroenergetics.subtitle.voltage_regulator": "Voltage Regulator Steps",
   "electroenergetics.subtitle.sulfur_hexafluoride_breaker_trip": "Sulfur Hexafluoride Breaker Trips",
 
   "electroenergetics.transformer.ratio": "Primary to Secondary Ratio",

--- a/src/main/resources/assets/electroenergetics/lang/es_es.json
+++ b/src/main/resources/assets/electroenergetics/lang/es_es.json
@@ -310,7 +310,7 @@
   "electroenergetics.subtitle.electric_train": "Sonidos de tren eléctrico",
   "electroenergetics.subtitle.hum": "Zumbido",
   "electroenergetics.subtitle.train_relay": "Relé de tren",
-  "electroenergetics.subtitle.votlage_regulator": "Paso del regulador de tensión",
+  "electroenergetics.subtitle.voltage_regulator": "Paso del regulador de tensión",
   "electroenergetics.tooltip.energy_meter.energy": "Energía total: %1$s",
   "electroenergetics.tooltip.energy_meter.owner": "Propietario: %1$s",
   "electroenergetics.tooltip.max_current": "Corriente máxima:",

--- a/src/main/resources/assets/electroenergetics/lang/zh_cn.json
+++ b/src/main/resources/assets/electroenergetics/lang/zh_cn.json
@@ -309,7 +309,7 @@
   "electroenergetics.subtitle.hum": "嗡",
   "electroenergetics.subtitle.sulfur_hexafluoride_breaker_trip": "六氟化硫断路器",
   "electroenergetics.subtitle.train_relay": "电车励磁音",
-  "electroenergetics.subtitle.votlage_regulator": "稳压器档位",
+  "electroenergetics.subtitle.voltage_regulator": "稳压器档位",
   "electroenergetics.tooltip.energy_meter.energy": "总用电量： %1$s",
   "electroenergetics.tooltip.energy_meter.owner": "所有者： %1$s",
   "electroenergetics.tooltip.max_current": "最大电流：",

--- a/src/main/resources/assets/electroenergetics/models/block/electric_shock_sign/block.json
+++ b/src/main/resources/assets/electroenergetics/models/block/electric_shock_sign/block.json
@@ -3,7 +3,7 @@
 	"credit": "Made with Blockbench",
 	"texture_size": [64, 64],
 	"textures": {
-		"0": "electroenergetics:block/high_votlage_sign",
+		"0": "electroenergetics:block/high_voltage_sign",
 		"1": "electroenergetics:block/electric_shock_sign",
 		"particle": "electroenergetics:block/electric_shock_sign"
 	},

--- a/src/main/resources/assets/electroenergetics/models/block/electric_shock_sign/block_attached.json
+++ b/src/main/resources/assets/electroenergetics/models/block/electric_shock_sign/block_attached.json
@@ -3,7 +3,7 @@
 	"credit": "Made with Blockbench",
 	"texture_size": [64, 64],
 	"textures": {
-		"0": "electroenergetics:block/high_votlage_sign",
+		"0": "electroenergetics:block/high_voltage_sign",
 		"1": "electroenergetics:block/electric_shock_sign",
 		"particle": "electroenergetics:block/electric_shock_sign"
 	},

--- a/src/main/resources/assets/electroenergetics/models/block/grounding_sign/block.json
+++ b/src/main/resources/assets/electroenergetics/models/block/grounding_sign/block.json
@@ -3,7 +3,7 @@
 	"credit": "Made with Blockbench",
 	"texture_size": [64, 64],
 	"textures": {
-		"0": "electroenergetics:block/high_votlage_sign",
+		"0": "electroenergetics:block/high_voltage_sign",
 		"1": "electroenergetics:block/grounding_sign",
 		"particle": "electroenergetics:block/grounding_sign"
 	},

--- a/src/main/resources/assets/electroenergetics/models/block/grounding_sign/block_attached.json
+++ b/src/main/resources/assets/electroenergetics/models/block/grounding_sign/block_attached.json
@@ -3,7 +3,7 @@
 	"credit": "Made with Blockbench",
 	"texture_size": [64, 64],
 	"textures": {
-		"0": "electroenergetics:block/high_votlage_sign",
+		"0": "electroenergetics:block/high_voltage_sign",
 		"1": "electroenergetics:block/grounding_sign",
 		"particle": "electroenergetics:block/grounding_sign"
 	},

--- a/src/main/resources/assets/electroenergetics/models/block/high_voltage_sign/block.json
+++ b/src/main/resources/assets/electroenergetics/models/block/high_voltage_sign/block.json
@@ -3,8 +3,8 @@
 	"credit": "Made with Blockbench",
 	"texture_size": [64, 64],
 	"textures": {
-		"0": "electroenergetics:block/high_votlage_sign",
-		"particle": "electroenergetics:block/high_votlage_sign"
+		"0": "electroenergetics:block/high_voltage_sign",
+		"particle": "electroenergetics:block/high_voltage_sign"
 	},
 	"elements": [
 		{

--- a/src/main/resources/assets/electroenergetics/models/block/high_voltage_sign/block_attached.json
+++ b/src/main/resources/assets/electroenergetics/models/block/high_voltage_sign/block_attached.json
@@ -3,8 +3,8 @@
 	"credit": "Made with Blockbench",
 	"texture_size": [64, 64],
 	"textures": {
-		"0": "electroenergetics:block/high_votlage_sign",
-		"particle": "electroenergetics:block/high_votlage_sign"
+		"0": "electroenergetics:block/high_voltage_sign",
+		"particle": "electroenergetics:block/high_voltage_sign"
 	},
 	"elements": [
 		{


### PR DESCRIPTION
This PR fixes a couple of misspellings of "voltage", which caused the subtitle to not work correctly, for example.