### PR TITLE
Add config variable for max converter power

### DIFF
--- a/src/main/java/com/george_vi/electroenergetics/config/CServer.java
+++ b/src/main/java/com/george_vi/electroenergetics/config/CServer.java
@@ -6,6 +6,7 @@ import net.neoforged.neoforge.common.ModConfigSpec;
 public class CServer extends ConfigBase {
 
     public final ConfigDouble wattFeTConversionRate = d(34, 0.0001d, "wattFeTConversionRate", "this many watts is one FE/tick");
+    public final ConfigDouble converterMaxPowerKw = d(100, 1, "converterMaxPower", "[in kW]");
     public final ConfigInt maxWireLength = i(128, 8, "wireLength", "[in Meters]");
     public final ConfigInt maxHeavilyInsulatedWireLength = i(32, 8, "heavilyInsulatedWireLength", "[in Meters]");
     public final ConfigInt maxBusWireLength = i(8, 1, "busWireLength", "[in Meters]");

--- a/src/main/java/com/george_vi/electroenergetics/content/converter/ConverterBlockEntity.java
+++ b/src/main/java/com/george_vi/electroenergetics/content/converter/ConverterBlockEntity.java
@@ -169,7 +169,7 @@ public class ConverterBlockEntity extends SmartBlockEntity implements IHaveGoggl
         final ConverterBlockEntity be;
 
         public ConverterEnergyStorage(ConverterBlockEntity be) {
-            super(Mth.floor(ConverterDevice.MAX_ENERGY / CEEConfigs.server().wattFeTConversionRate.get()));
+            super(Mth.floor(CEEConfigs.server().converterMaxPowerKw.get() * 1000 / CEEConfigs.server().wattFeTConversionRate.get()));
             this.be = be;
         }
 

--- a/src/main/java/com/george_vi/electroenergetics/content/converter/ConverterDevice.java
+++ b/src/main/java/com/george_vi/electroenergetics/content/converter/ConverterDevice.java
@@ -21,10 +21,12 @@ public class ConverterDevice extends SimpleElectricalDevice {
     public double storedEnergy;
     public ConverterBlockEntity be;
 
-    static final int MAX_ENERGY = 100_000;
-
     public ConverterDevice(Level level, BlockPos pos, DevicesSavedData deviceSD, SimulatedDeviceType<?> type) {
         super(level, pos, deviceSD, type);
+    }
+
+    private double getMaxEnergy() {
+        return CEEConfigs.server().converterMaxPowerKw.get() * 1000;
     }
 
     @Override
@@ -50,14 +52,14 @@ public class ConverterDevice extends SimpleElectricalDevice {
 
             this.storedEnergy -= power;
 
-            if (this.storedEnergy < MAX_ENERGY && level.isLoaded(pos)) {
+            if (this.storedEnergy < getMaxEnergy() && level.isLoaded(pos)) {
                 BlockState state = level.getBlockState(pos);
                 IEnergyStorage energyStorage = level.getCapability(
                         Capabilities.EnergyStorage.BLOCK,
                         pos.relative(state.getValue(ConverterBlock.FACING).getOpposite()),
                         state.getValue(ConverterBlock.FACING));
                 if (energyStorage != null)
-                    this.storedEnergy += energyStorage.extractEnergy((int) ((MAX_ENERGY - this.storedEnergy) / CEEConfigs.server().wattFeTConversionRate.get()), false) * CEEConfigs.server().wattFeTConversionRate.get();
+                    this.storedEnergy += energyStorage.extractEnergy((int) ((getMaxEnergy() - this.storedEnergy) / CEEConfigs.server().wattFeTConversionRate.get()), false) * CEEConfigs.server().wattFeTConversionRate.get();
             }
 
             displayedPower = power;
@@ -79,11 +81,11 @@ public class ConverterDevice extends SimpleElectricalDevice {
 
             displayedPower = -power;
             if (vd > 1)
-                this.resistance = Math.max(20, vd / (Math.max((MAX_ENERGY - this.storedEnergy), 0.01) / vd));
+                this.resistance = Math.max(20, vd / (Math.max((getMaxEnergy() - this.storedEnergy), 0.01) / vd));
 
         }
 
-        this.storedEnergy = Mth.clamp(this.storedEnergy, 0, MAX_ENERGY);
+        this.storedEnergy = Mth.clamp(this.storedEnergy, 0, getMaxEnergy());
 
         if (this.be == null && level.isLoaded(pos))
             if (level.getBlockEntity(pos) instanceof ConverterBlockEntity be)


### PR DESCRIPTION
This PR makes the converter power limit a config variable rather than a hardcoded value. The 100 kW limit can become an issue with high-power machines from other mods, so now it can be configured.

Previous PR (#84) was based on the wrong branch, this one fixes it.