### PR TITLE
Fixed transformer cores chunk load/unload spam

### DIFF
--- a/src/main/java/com/george_vi/electroenergetics/content/transmission_distribution/transformer/TransformerCoreDevice.java
+++ b/src/main/java/com/george_vi/electroenergetics/content/transmission_distribution/transformer/TransformerCoreDevice.java
@@ -66,7 +66,7 @@ public class TransformerCoreDevice extends SimpleElectricalDevice {
         double power = TransformerBehaviour.postTick(nodes, results, transformerData);
 
         if (be == null)
-            if (level.getBlockEntity(pos) instanceof TransformerCoreBlockEntity be)
+            if (level.isLoaded(pos) && level.getBlockEntity(pos) instanceof TransformerCoreBlockEntity be)
                 this.be = be;
 
         if (be != null) {


### PR DESCRIPTION
Fixes a pretty simple mistake with transformer core postTick logic. Just seems like george forgot to add a check to make sure the area the block is in is loaded before attempting to grab the BlockEntity. This issue is not present in regular transformers.