### PR TITLE
Fix handling of rotation properties on electric gauges

### DIFF
--- a/src/main/java/com/george_vi/electroenergetics/content/gauge/ElectricGaugeBlock.java
+++ b/src/main/java/com/george_vi/electroenergetics/content/gauge/ElectricGaugeBlock.java
@@ -150,13 +150,14 @@ public class ElectricGaugeBlock extends SimpleElectricalDeviceBlock<GaugeDevice>
 
     @Override
     public BlockState rotate(BlockState state, Rotation rot) {
+        state = state.setValue(FACING, rot.rotate(state.getValue(FACING)));
         if (rot.ordinal() % 2 == 1)
             state = state.cycle(GaugeBlock.AXIS_ALONG_FIRST_COORDINATE);
-        return super.rotate(state, rot);
+        return state;
     }
 
     @Override
     public BlockState mirror(BlockState state, Mirror mirrorIn) {
-        return state.rotate(mirrorIn.getRotation(state.getValue(FACING)));
+        return state.setValue(FACING, mirrorIn.mirror(state.getValue(FACING)));
     }
 }


### PR DESCRIPTION
This PR improves handling of rotation on the voltmeter and the ammeter. Previously, when building schematics which contained gauges, they would not respect the schematic and always be facing the default direction. It seems like this is because `super.rotate()` is a no-op in this context (`SimpleElectricalDeviceBlock` doesn't override it, so it gets default `Block` behaviour).

This PR fixes this, which makes printing from schematics conserve rotation.