### PR TITLE
Handle CEE devices placed during worldgen

### DIFF
--- a/src/main/java/com/george_vi/electroenergetics/mixins/LevelChunkMixin.java
+++ b/src/main/java/com/george_vi/electroenergetics/mixins/LevelChunkMixin.java
@@ -4,16 +4,18 @@ import com.george_vi.electroenergetics.devices.device.DeviceBlock;
 import com.george_vi.electroenergetics.devices.device.DevicesSavedData;
 import com.george_vi.electroenergetics.devices.device.SimulatedDeviceType;
 import net.minecraft.core.BlockPos;
-import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.chunk.LevelChunk;
+import net.minecraft.world.level.chunk.LevelChunkSection;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(LevelChunk.class)
@@ -41,5 +43,49 @@ public class LevelChunkMixin {
 //
 //        DevicesSavedData sd = DevicesSavedData.load(level);
 //        sd.addDevice(type, pos, new CompoundTag());
+    }
+
+    /**
+     * This catches device blocks placed during worldgen that weren't registered via setBlockState. It seems
+     * like setBlockState isn't usually called during worldgen, so this is necessary for blocks to be registered
+     * as devices if they are part of worldgen.
+     */
+    @Inject(method = "postProcessGeneration", at = @At("TAIL"), remap = false)
+    public void onPostProcessGeneration(CallbackInfo ci) {
+        if (!(level instanceof ServerLevel serverLevel))
+            return;
+
+        LevelChunk self = (LevelChunk)(Object)this;
+        DevicesSavedData sd = DevicesSavedData.load(serverLevel);
+        ChunkPos chunkPos = self.getPos();
+        LevelChunkSection[] sections = self.getSections();
+
+        int minY = self.getMinBuildHeight();
+
+        for (int sectionIndex = 0; sectionIndex < sections.length; sectionIndex++) {
+            LevelChunkSection section = sections[sectionIndex];
+            if (section == null || section.hasOnlyAir())
+                continue;
+
+            int sectionY = minY + (sectionIndex * 16);
+
+            for (int x = 0; x < 16; x++) {
+                for (int y = 0; y < 16; y++) {
+                    for (int z = 0; z < 16; z++) {
+                        BlockState state = section.getBlockState(x, y, z);
+                        if (state.getBlock() instanceof DeviceBlock<?> db) {
+                            BlockPos pos = new BlockPos(
+                                chunkPos.getMinBlockX() + x,
+                                sectionY + y,
+                                chunkPos.getMinBlockZ() + z
+                            );
+                            if (sd.getDevice(pos) == null) {
+                                sd.addDevice(db.getDevice(), pos, db.getDefaultDeviceData(serverLevel, pos, state));
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/main/java/com/george_vi/electroenergetics/mixins/LevelChunkMixin.java
+++ b/src/main/java/com/george_vi/electroenergetics/mixins/LevelChunkMixin.java
@@ -45,6 +45,8 @@ public class LevelChunkMixin {
 //        sd.addDevice(type, pos, new CompoundTag());
     }
 
+    private static final java.util.function.Predicate<BlockState> IS_DEVICE_BLOCK = state -> state.getBlock() instanceof DeviceBlock<?>;
+
     /**
      * This catches device blocks placed during worldgen that weren't registered via setBlockState. It seems
      * like setBlockState isn't usually called during worldgen, so this is necessary for blocks to be registered
@@ -64,7 +66,7 @@ public class LevelChunkMixin {
 
         for (int sectionIndex = 0; sectionIndex < sections.length; sectionIndex++) {
             LevelChunkSection section = sections[sectionIndex];
-            if (section == null || section.hasOnlyAir())
+            if (section == null || !section.maybeHas(IS_DEVICE_BLOCK))
                 continue;
 
             int sectionY = minY + (sectionIndex * 16);


### PR DESCRIPTION
In my testing, it appears like usually `setBlockState` isn't called for CEE devices placed during worldgen. This leads to them being non-functional. One exception to this is blocks placed in water, which do get the call and are properly registered. This PR adds a `onPostProcessGeneration` mixin that scans the chunk for missing devices.

I am not sure if this is the best approach. I'm not a fan of having to scan the whole chunk, but not every CEE device is a BlockEntity. I think it should be fine since it only happens once when a chunk is generated, but let me know if there's a more efficient way of doing this.