### PR TITLE
Fix DFS traversal for transformer core

### DIFF
--- a/src/main/java/com/george_vi/electroenergetics/content/transmission_distribution/transformer/TransformerCoreBlockEntity.java
+++ b/src/main/java/com/george_vi/electroenergetics/content/transmission_distribution/transformer/TransformerCoreBlockEntity.java
@@ -131,7 +131,7 @@ public class TransformerCoreBlockEntity extends SmartBlockEntity implements IHav
             if (nextPos.distSqr(worldPosition) > 16)
                 continue;
             BlockState state = level.getBlockState(nextPos);
-            if ((waterlogged && !level.getFluidState(currentPos).isEmpty()) ||
+            if ((waterlogged && !level.getFluidState(nextPos).isEmpty()) ||
                     (CEEBlocks.TRANSFORMER_CORE.has(state) && direction == getBlockState().getValue(TransformerCoreBlock.FACING)) ||
                 state.is(CEETags.TRANSFORMER_HEAT_DISSIPATORS))
                 if (visited.add(nextPos))


### PR DESCRIPTION
This PR addresses an error in DFS traversal code of `TransformerCoreBlockEntity`. Since it keeps checking `currentPos` in the direction loop, having the center block waterlogged will mark all 6 sides as dissipators, which makes it overestimate the dissipation capacity.

Note that this change will break existing setups, in particular compact ones. Since previously waterlogging the block would make it consider 6 sides as dissipators, waterlogging would greatly boost dissipation. After this change, waterlogging the transformer core with water has no effect, and it needs to be waterlogged in transformer oil to boost dissipation. Larger cooling setups are required to achieve the same dissipation.

This issue was originally found by @ItsEvilh.