### PR TITLE
Fix ground tag

### DIFF
--- a/src/main/resources/data/electroenergetics/tags/block/earth.json
+++ b/src/main/resources/data/electroenergetics/tags/block/earth.json
@@ -1,9 +1,8 @@
 {
   "values": [
-    "#minecraft:stone",
     "#minecraft:dirt",
     "#minecraft:sand",
     "#c:gravels",
-    "#c:stones",
+    "#c:stones"
   ]
 }


### PR DESCRIPTION
It would appear like #117 introduced an invalid tag, since now the mod fails to load the tag with message:
`Couldn't load tag electroenergetics:earth as it is missing following references:`
`#minecraft:stone (from mod/electroenergetics)`

This PR fixes it by removing this entry. `#c:stones` should cover this case.