### PR TITLE
Implement opening the Config screen through NeoForge's modlist

### DIFF
--- a/src/main/java/com/george_vi/electroenergetics/CEEClient.java
+++ b/src/main/java/com/george_vi/electroenergetics/CEEClient.java
@@ -1,0 +1,27 @@
+package com.george_vi.electroenergetics;
+
+import net.createmod.catnip.config.ui.BaseConfigScreen;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.bus.api.IEventBus;
+import net.neoforged.fml.ModContainer;
+import net.neoforged.fml.ModList;
+import net.neoforged.fml.common.Mod;
+import net.neoforged.fml.event.lifecycle.FMLLoadCompleteEvent;
+import net.neoforged.neoforge.client.gui.IConfigScreenFactory;
+
+import java.util.function.Supplier;
+
+@Mod(value = CreateElectroEnergetics.ID, dist = Dist.CLIENT)
+public class CEEClient {
+    public CEEClient(IEventBus modEventBus) {
+        modEventBus.addListener(CEEClient::onLoadComplete);
+    }
+
+    public static void onLoadComplete(FMLLoadCompleteEvent event) {
+        ModContainer container = ModList.get()
+                .getModContainerById(CreateElectroEnergetics.ID)
+                .orElseThrow(() -> new IllegalStateException("Create: Electro Energetics mod container missing on LoadComplete"));
+        Supplier<IConfigScreenFactory> configScreen = () -> (mc, previousScreen) -> new BaseConfigScreen(previousScreen, CreateElectroEnergetics.ID);
+        container.registerExtensionPoint(IConfigScreenFactory.class, configScreen);
+    }
+}


### PR DESCRIPTION
Still uses Catnip, just like if opened through "Access configs for other mods" list from Create's config screen.

<details> <summary>Pictures</summary>

---
<img width="1280" height="720" alt="2026-06-18_19 46 41" src="https://github.com/user-attachments/assets/fbed636d-736c-48ea-afe5-1ff3128e98f2"/>

---
<img width="1280" height="720" alt="2026-06-18_19 46 44" src="https://github.com/user-attachments/assets/78ef478d-fd98-49c7-8d65-cd15cc4f54db"/>

---

</details>

Had to Create a `CEEClient` class for it so dedicated server doesn't get screwed trying to load client-side code (I'm having flashbacks now). If there's a cleaner way you want me to use, lemme know!