### PR TITLE
Make motors working at lower voltage when speed is unlocked

### DIFF
--- a/src/main/java/com/george_vi/electroenergetics/content/electric_motor/ElectricMotorBlockEntity.java
+++ b/src/main/java/com/george_vi/electroenergetics/content/electric_motor/ElectricMotorBlockEntity.java
@@ -271,7 +271,7 @@ public class ElectricMotorBlockEntity extends GeneratingKineticBlockEntity {
 
     @Override
     public float getGeneratedSpeed() {
-        return convertToDirection(averageVoltage.get() < 80 ? 0 : getMotorSpeed(), getBlockState().getValue(ElectricMotorBlock.FACING));
+        return convertToDirection(averageVoltage.get() < 80 && !generatedSpeed.isUnlocked() ? 0 : getMotorSpeed(), getBlockState().getValue(ElectricMotorBlock.FACING));
     }
 
     private float getMotorSpeed() {


### PR DESCRIPTION
### Description
As the title says
### Motivation
Unlocking voltage limit makes it convenience to build analog operation circuits.
It could works as an integrator through variac.