### PR TITLE
feat: synchroscope comparator output

### DIFF
--- a/src/main/java/com/george_vi/electroenergetics/content/synchroscope/SynchroscopeBlock.java
+++ b/src/main/java/com/george_vi/electroenergetics/content/synchroscope/SynchroscopeBlock.java
@@ -13,6 +13,7 @@ import com.simibubi.create.foundation.block.ProperWaterloggedBlock;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.util.Mth;
 import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
@@ -71,6 +72,18 @@ public class SynchroscopeBlock extends SimpleElectricalDeviceBlock<SynchroscopeD
     @Override
     protected FluidState getFluidState(BlockState state) {
         return fluidState(state);
+    }
+
+    @Override
+    protected boolean hasAnalogOutputSignal(BlockState state) {
+        return true;
+    }
+
+    @Override
+    protected int getAnalogOutputSignal(BlockState state, Level level, BlockPos pos) {
+        if (level.getBlockEntity(pos) instanceof SynchroscopeBlockEntity be)
+            return Mth.clamp(be.redstoneSignal, 0, 15);
+        return 0;
     }
 
     @Override

--- a/src/main/java/com/george_vi/electroenergetics/content/synchroscope/SynchroscopeBlock.java
+++ b/src/main/java/com/george_vi/electroenergetics/content/synchroscope/SynchroscopeBlock.java
@@ -7,11 +7,13 @@ import com.george_vi.electroenergetics.CEESimulatedDevices;
 import com.george_vi.electroenergetics.foundation.CEELang;
 import com.george_vi.electroenergetics.foundation.base.SimpleElectricalDeviceBlock;
 import com.george_vi.electroenergetics.devices.device.SimulatedDeviceType;
+import com.george_vi.electroenergetics.foundation.redstone.DirectionalAnalogOutputBlock;
 import com.simibubi.create.content.equipment.wrench.IWrenchable;
 import com.simibubi.create.foundation.block.IBE;
 import com.simibubi.create.foundation.block.ProperWaterloggedBlock;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.Direction.Axis;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.util.Mth;
 import net.minecraft.world.item.context.BlockPlaceContext;
@@ -33,7 +35,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
 
-public class SynchroscopeBlock extends SimpleElectricalDeviceBlock<SynchroscopeDevice> implements IWrenchable, IBE<SynchroscopeBlockEntity>, ProperWaterloggedBlock {
+public class SynchroscopeBlock extends SimpleElectricalDeviceBlock<SynchroscopeDevice> implements IWrenchable, IBE<SynchroscopeBlockEntity>, ProperWaterloggedBlock, DirectionalAnalogOutputBlock {
     public static final BooleanProperty WATERLOGGED = BlockStateProperties.WATERLOGGED;
     public static final DirectionProperty FACING = BlockStateProperties.HORIZONTAL_FACING;
 
@@ -83,6 +85,29 @@ public class SynchroscopeBlock extends SimpleElectricalDeviceBlock<SynchroscopeD
     protected int getAnalogOutputSignal(BlockState state, Level level, BlockPos pos) {
         if (level.getBlockEntity(pos) instanceof SynchroscopeBlockEntity be)
             return Mth.clamp(be.redstoneSignal, 0, 15);
+        return 0;
+    }
+
+    @Override
+    public int getAnalogOutputSignal(BlockState state, Level level, BlockPos pos, Direction dir) {
+        if (level.getBlockEntity(pos) instanceof SynchroscopeBlockEntity be) {
+            Direction facing = state.getValue(FACING);
+            Axis facingAxis = facing.getAxis();
+
+            Direction side = dir.getOpposite();
+            Axis sideAxis = side.getAxis();
+
+            int signal;
+            if (sideAxis.isVertical() || sideAxis == facingAxis) {
+                signal = be.redstoneSignal;
+            } else if (side == facing.getClockWise()) {
+                signal = be.cwRedstoneSignal;
+            } else { // counterclockwise
+                signal = be.ccwRedstoneSignal;
+            }
+
+            return Mth.clamp(signal, 0, 15);
+        }
         return 0;
     }
 

--- a/src/main/java/com/george_vi/electroenergetics/content/synchroscope/SynchroscopeBlockEntity.java
+++ b/src/main/java/com/george_vi/electroenergetics/content/synchroscope/SynchroscopeBlockEntity.java
@@ -28,6 +28,7 @@ public class SynchroscopeBlockEntity extends SmartBlockEntity implements IHaveHo
     int counter = 0;
     public boolean validConnection;
     LerpedFloat smoothPhase = LerpedFloat.angular();
+    int redstoneSignal;
 
     public SynchroscopeBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState state) {
         super(type, pos, state);
@@ -47,6 +48,14 @@ public class SynchroscopeBlockEntity extends SmartBlockEntity implements IHaveHo
 //        if (AngleHelper.getShortestAngleDiff(smoothPhase.getValue(), phaseOffset) > 1)
 //            smoothPhase.chase(phaseOffset, 1, LerpedFloat.Chaser.EXP);
         smoothPhase.tickChaser();
+
+        if (!level.isClientSide()) {
+            int newRedstoneSignal = ((-Math.round(phaseOffset * (16.0f / 360.0f)) % 16) + 16) % 16;
+            if (newRedstoneSignal != redstoneSignal) {
+                redstoneSignal = newRedstoneSignal;
+                setChanged();
+            }
+        }
     }
 
     @Override

--- a/src/main/java/com/george_vi/electroenergetics/content/synchroscope/SynchroscopeBlockEntity.java
+++ b/src/main/java/com/george_vi/electroenergetics/content/synchroscope/SynchroscopeBlockEntity.java
@@ -8,7 +8,6 @@ import com.simibubi.create.foundation.item.TooltipHelper;
 import com.simibubi.create.foundation.utility.CreateLang;
 import net.createmod.catnip.animation.LerpedFloat;
 import net.createmod.catnip.lang.FontHelper;
-import net.createmod.catnip.math.AngleHelper;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.HolderLookup;
@@ -29,6 +28,8 @@ public class SynchroscopeBlockEntity extends SmartBlockEntity implements IHaveHo
     public boolean validConnection;
     LerpedFloat smoothPhase = LerpedFloat.angular();
     int redstoneSignal;
+    int ccwRedstoneSignal;
+    int cwRedstoneSignal;
 
     public SynchroscopeBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState state) {
         super(type, pos, state);
@@ -51,8 +52,13 @@ public class SynchroscopeBlockEntity extends SmartBlockEntity implements IHaveHo
 
         if (!level.isClientSide()) {
             int newRedstoneSignal = ((-Math.round(phaseOffset * (16.0f / 360.0f)) % 16) + 16) % 16;
-            if (newRedstoneSignal != redstoneSignal) {
+            int sidedSignal = (((-Math.round(phaseOffset * (32 / 360.0f)) % 32) + 16) % 32) - 16; // range -16 to 15
+            int newCwSignal = Mth.clamp(sidedSignal, 0, 15);
+            int newCcwRightSignal = Mth.clamp(-sidedSignal - 1, 0, 15);
+            if (newRedstoneSignal != redstoneSignal || newCwSignal != ccwRedstoneSignal || newCcwRightSignal != cwRedstoneSignal) {
                 redstoneSignal = newRedstoneSignal;
+                ccwRedstoneSignal = newCwSignal;
+                cwRedstoneSignal = newCcwRightSignal;
                 setChanged();
             }
         }

--- a/src/main/java/com/george_vi/electroenergetics/foundation/redstone/DirectionalAnalogOutputBlock.java
+++ b/src/main/java/com/george_vi/electroenergetics/foundation/redstone/DirectionalAnalogOutputBlock.java
@@ -1,0 +1,14 @@
+package com.george_vi.electroenergetics.foundation.redstone;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
+
+public interface DirectionalAnalogOutputBlock {
+    /**
+     * Returns the analog signal this block emits. This is the signal a comparator can read from it from a specific side.
+     *
+     */
+    int getAnalogOutputSignal(BlockState state, Level level, BlockPos pos, Direction dir);
+}

--- a/src/main/java/com/george_vi/electroenergetics/mixins/ComparatorBlockMixin.java
+++ b/src/main/java/com/george_vi/electroenergetics/mixins/ComparatorBlockMixin.java
@@ -1,0 +1,24 @@
+package com.george_vi.electroenergetics.mixins;
+
+import com.george_vi.electroenergetics.foundation.redstone.DirectionalAnalogOutputBlock;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.ComparatorBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(ComparatorBlock.class)
+public class ComparatorBlockMixin {
+    @WrapOperation(method = "getInputSignal", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/block/state/BlockState;getAnalogOutputSignal(Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;)I"))
+    private int getDirectionalSignal(BlockState instance, Level level, BlockPos pos, Operation<Integer> original, @Local Direction direction) {
+        if (instance.getBlock() instanceof DirectionalAnalogOutputBlock b) {
+            return b.getAnalogOutputSignal(instance, level, pos, direction);
+        }
+        return original.call(instance, level, pos);
+    }
+}

--- a/src/main/resources/electroenergetics.mixins.json
+++ b/src/main/resources/electroenergetics.mixins.json
@@ -22,6 +22,7 @@
     "BlockStateBaseMixin",
     "CarriageContraptionMixin",
     "CarriageMixin",
+    "ComparatorBlockMixin",
     "FluidPropagatorMixin",
     "LevelChunkMixin",
     "LivingEntityMixin",


### PR DESCRIPTION
The synchroscope now has a comparator output of 0 when the dial is at the top (i.e. synchronized), increasing to 15 clockwise. This allows, with clever redstone, automatic synchronization.