### PR TITLE
Fix Issue #201

### DIFF
--- a/src/main/java/com/george_vi/electroenergetics/config/CSimulation.java
+++ b/src/main/java/com/george_vi/electroenergetics/config/CSimulation.java
@@ -6,6 +6,8 @@ import org.jetbrains.annotations.NotNull;
 public class CSimulation extends ConfigBase {
     public final ConfigBool optimizeGraph = b(true, "optimizeGraph", "Don't turn off unless you want to cook your TPS");
     public final ConfigInt microTicks = i(1, 1, 64, "microTicks", "This describes how many times the simulation is run every tick.");
+    public final ConfigFloat capacitySolverDamp = f(0.5005f, 0.5f, 1.0f, "capacitySolverDamp",
+            "Balances solver stability and capacitor accuracy (0.5 = most accurate, 1.0 = most stable).");
 
     @Override
     public @NotNull String getName() {

--- a/src/main/java/com/george_vi/electroenergetics/foundation/electrical_properties/CapacitorProperties.java
+++ b/src/main/java/com/george_vi/electroenergetics/foundation/electrical_properties/CapacitorProperties.java
@@ -1,5 +1,6 @@
 package com.george_vi.electroenergetics.foundation.electrical_properties;
 
+import com.george_vi.electroenergetics.config.CEEConfigs;
 import com.george_vi.electroenergetics.simulation.electrical_properties.MicroTickingElectricalProperties;
 
 public class CapacitorProperties extends MicroTickingElectricalProperties {
@@ -10,6 +11,8 @@ public class CapacitorProperties extends MicroTickingElectricalProperties {
      * <p>Write only during the preTick phase.</p>
      */
     public double lastVoltage;
+    public double lastCurrent; // save for Damped Trapezoidal
+    private double currentConductance; // pass raw data to afterTick
 
     /**
      * <p>Specifies the capacitance of the capacitor behavior.</p>
@@ -31,16 +34,18 @@ public class CapacitorProperties extends MicroTickingElectricalProperties {
         lastVoltage =
                 allVoltages[n1 * totalMicroTicks + microTick] -
                 allVoltages[n2 * totalMicroTicks + microTick];
+        lastCurrent = currentConductance * lastVoltage - this.currentSource;
     }
 
     private void tickCapacitor(int totalMicroTicks) {
+        double alpha = CEEConfigs.server().simulationConfig.capacitySolverDamp.get();
         double capacitance = Math.max(this.capacitance, 1e-12d);
         double timeStep = 0.05 / totalMicroTicks;
 
-        double conductance = capacitance / timeStep;
-        double historyCurrent = conductance * lastVoltage;
+        this.currentConductance = capacitance / (alpha * timeStep);
+        double historyCurrent = currentConductance * lastVoltage + ((1 - alpha) / alpha) * lastCurrent;
 
-        this.resistance = 1 / conductance;
+        this.resistance = 1 / currentConductance;
         this.currentSource = historyCurrent;
     }
 }


### PR DESCRIPTION
### Description
Fix #201 
Make capacitors simulated with Damped Trapezoidal to lower the unexpected ESR < 0.1Ohm.
At the same time, it changes the relation between equivalent capacitance and frequency, widens effective bandwidth.

For the contrast:
<img width="1361" height="735" alt="contrast" src="https://github.com/user-attachments/assets/21e0223a-a5bc-4192-bdb9-2e2114163a7e" />

I think the new method is more friendly with filters.
The alpha is adjustable in config with default 0.5005.

The performance loss is not significant.