### PR TITLE
Fix Electric Gauge CC Compat Bug & Add Scale to Energy Meter(Block)

### DIFF
--- a/src/main/java/com/george_vi/electroenergetics/compat/computercraft/peripherals/ElectricGaugePeripheral.java
+++ b/src/main/java/com/george_vi/electroenergetics/compat/computercraft/peripherals/ElectricGaugePeripheral.java
@@ -15,7 +15,7 @@ public class ElectricGaugePeripheral extends SyncedPeripheral<ElectricGaugeBlock
     }
 
     @LuaFunction
-    public final float getValue() {
-        return (float) (blockEntity.voltmeter ? blockEntity.voltage : blockEntity.voltage / 0.01) * blockEntity.scaling.getValue();
+    public final double getValue() {
+        return (blockEntity.voltmeter ? blockEntity.voltage : blockEntity.voltage / 0.01) * blockEntity.scaling.getScale();
     }
 }

--- a/src/main/java/com/george_vi/electroenergetics/compat/computercraft/peripherals/EnergyMeterPeripheral.java
+++ b/src/main/java/com/george_vi/electroenergetics/compat/computercraft/peripherals/EnergyMeterPeripheral.java
@@ -1,10 +1,8 @@
 package com.george_vi.electroenergetics.compat.computercraft.peripherals;
 
-import com.george_vi.electroenergetics.content.energy_meter.ChangeEnergyMeterStatePacket;
 import com.george_vi.electroenergetics.content.energy_meter.EnergyMeterBlockEntity;
 import com.simibubi.create.compat.computercraft.implementation.peripherals.SyncedPeripheral;
 import dan200.computercraft.api.lua.LuaFunction;
-import net.createmod.catnip.platform.CatnipServices;
 
 public class EnergyMeterPeripheral extends SyncedPeripheral<EnergyMeterBlockEntity> {
 	public EnergyMeterPeripheral(EnergyMeterBlockEntity blockEntity) {
@@ -23,6 +21,6 @@ public class EnergyMeterPeripheral extends SyncedPeripheral<EnergyMeterBlockEnti
 
 	@LuaFunction
 	public final double getTotalEnergy() {
-		return blockEntity.totalEnergy;
+		return blockEntity.totalEnergy * blockEntity.scale.getScale();
 	}
 }

--- a/src/main/java/com/george_vi/electroenergetics/content/energy_meter/ActivePowerDisplaySource.java
+++ b/src/main/java/com/george_vi/electroenergetics/content/energy_meter/ActivePowerDisplaySource.java
@@ -14,7 +14,7 @@ public class ActivePowerDisplaySource extends NumericSingleLineDisplaySource {
         if (!(blockEntity instanceof EnergyMeterBlockEntity be))
             return ZERO.copy();
 
-        return CEELang.formatPower(be.activePower).component();
+        return CEELang.formatPower(be.activePower * be.scale.getScale()).component();
     }
 
     @Override

--- a/src/main/java/com/george_vi/electroenergetics/content/energy_meter/EnergyMeterBlockEntity.java
+++ b/src/main/java/com/george_vi/electroenergetics/content/energy_meter/EnergyMeterBlockEntity.java
@@ -2,18 +2,24 @@ package com.george_vi.electroenergetics.content.energy_meter;
 
 import com.george_vi.electroenergetics.CEEBlockEntityTypes;
 import com.george_vi.electroenergetics.compat.computercraft.CCProxy;
+import com.george_vi.electroenergetics.foundation.CEELang;
+import com.george_vi.electroenergetics.foundation.scroll_value.ScalingScrollValueBehaviour;
 import com.simibubi.create.compat.Mods;
 import com.simibubi.create.compat.computercraft.AbstractComputerBehaviour;
 import com.simibubi.create.foundation.blockEntity.SmartBlockEntity;
 import com.simibubi.create.foundation.blockEntity.behaviour.BlockEntityBehaviour;
+import com.simibubi.create.foundation.blockEntity.behaviour.ValueBoxTransform;
 import dan200.computercraft.api.peripheral.PeripheralCapability;
-import net.createmod.catnip.animation.AnimationTickHolder;
 import net.createmod.catnip.animation.LerpedFloat;
+import net.createmod.catnip.math.VecHelper;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.capabilities.RegisterCapabilitiesEvent;
 
 import java.util.List;
@@ -34,6 +40,7 @@ public class EnergyMeterBlockEntity extends SmartBlockEntity {
     public UUID owner;
 
     public AbstractComputerBehaviour computerBehaviour;
+    public ScalingScrollValueBehaviour scale;
 
     public void setTotalEnergy(double newTotalEnergy) {
         double d = (Math.abs(newTotalEnergy - totalEnergy));
@@ -82,6 +89,27 @@ public class EnergyMeterBlockEntity extends SmartBlockEntity {
     @Override
     public void addBehaviours(List<BlockEntityBehaviour> behaviours) {
         behaviours.add(computerBehaviour = CCProxy.behaviour(this));
+        behaviours.add(scale = new ScalingScrollValueBehaviour(CEELang.translateDirect("gauge.scaling"),
+                this, new ValueBox()));
+    }
+
+    static class ValueBox extends ValueBoxTransform.Sided {
+
+        @Override
+        protected Vec3 getSouthLocation() {
+            return VecHelper.voxelSpace(8, 8, 16);
+        }
+
+        @Override
+        public Vec3 getLocalOffset(LevelAccessor level, BlockPos pos, BlockState state) {
+            return super.getLocalOffset(level, pos, state);
+        }
+
+        @Override
+        protected boolean isSideActive(BlockState state, Direction direction) {
+            Direction facing = state.getValue(EnergyMeterBlock.FACING);
+            return direction.getOpposite() == facing;
+        }
     }
 
     public static void registerCapabilities(RegisterCapabilitiesEvent event) {

--- a/src/main/java/com/george_vi/electroenergetics/content/energy_meter/EnergyMeterDevice.java
+++ b/src/main/java/com/george_vi/electroenergetics/content/energy_meter/EnergyMeterDevice.java
@@ -93,7 +93,7 @@ public class EnergyMeterDevice extends SimpleElectricalDevice {
             else {
                 this.be.setTotalEnergy((float) this.totalEnergy);
                 this.be.activePower = this.isClosed ? power : 0;
-                if (be.owner != null && totalEnergy > 10_000) {
+                if (be.owner != null && totalEnergy * be.scale.getScale() > 10_000) {
                     Player player = Objects.requireNonNull(level.getServer()).getPlayerList().getPlayer(be.owner);
 
                     if (player != null)

--- a/src/main/java/com/george_vi/electroenergetics/content/energy_meter/EnergyMeterDisplaySource.java
+++ b/src/main/java/com/george_vi/electroenergetics/content/energy_meter/EnergyMeterDisplaySource.java
@@ -14,7 +14,7 @@ public class EnergyMeterDisplaySource extends NumericSingleLineDisplaySource {
         if (!(blockEntity instanceof EnergyMeterBlockEntity be))
             return ZERO.copy();
 
-        return CEELang.formatEnergy(be.totalEnergy * 1000).component();
+        return CEELang.formatEnergy(be.totalEnergy * 1000 * be.scale.getScale()).component();
     }
 
     @Override

--- a/src/main/java/com/george_vi/electroenergetics/content/energy_meter/EnergyMeterScreen.java
+++ b/src/main/java/com/george_vi/electroenergetics/content/energy_meter/EnergyMeterScreen.java
@@ -5,7 +5,6 @@ import com.george_vi.electroenergetics.CEEGuiTextures;
 import com.george_vi.electroenergetics.CreateElectroEnergetics;
 import com.simibubi.create.foundation.gui.AllIcons;
 import com.simibubi.create.foundation.gui.widget.IconButton;
-import net.createmod.catnip.animation.AnimationTickHolder;
 import net.createmod.catnip.gui.AbstractSimiScreen;
 import net.createmod.catnip.gui.element.GuiGameElement;
 import net.createmod.catnip.lang.Lang;
@@ -14,7 +13,7 @@ import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.chat.Component;
-import net.minecraft.util.Mth;
+import org.jetbrains.annotations.NotNull;
 import org.lwjgl.glfw.GLFW;
 
 import java.util.List;
@@ -42,7 +41,7 @@ public class EnergyMeterScreen extends AbstractSimiScreen {
         super.init();
 
         confirmButton = new IconButton(guiLeft + CEEGuiTextures.ENERGY_METER.getWidth() - 33, guiTop + CEEGuiTextures.ENERGY_METER.getHeight() - 25, AllIcons.I_CONFIRM);
-        confirmButton.withCallback(() -> onClose());
+        confirmButton.withCallback(this::onClose);
         addRenderableWidget(confirmButton);
 
         disconnectX = guiLeft + CEEGuiTextures.ENERGY_METER.getWidth() - 28;
@@ -52,7 +51,7 @@ public class EnergyMeterScreen extends AbstractSimiScreen {
     }
 
     @Override
-    protected void renderWindow(GuiGraphics graphics, int mouseX, int mouseY, float partialTicks) {
+    protected void renderWindow(@NotNull GuiGraphics graphics, int mouseX, int mouseY, float partialTicks) {
         int x = guiLeft;
         int y = guiTop;
 
@@ -65,8 +64,8 @@ public class EnergyMeterScreen extends AbstractSimiScreen {
         int stringWidth = font.width(title);
         graphics.drawString(font, title, x - stringWidth / 2 + windowWidth / 2, y + 4, 0xFFFFEE);
 
-        double smoothTotalEnergy = be.smoothTotalEnergy.getValue(partialTicks);
-        double totalEnergy = be.smoothTotalEnergy.getValue(partialTicks);
+        double smoothTotalEnergy = be.smoothTotalEnergy.getValue(partialTicks) * be.scale.getScale();
+        double totalEnergy = be.smoothTotalEnergy.getValue(partialTicks) * be.scale.getScale();
 
 
         totalEnergy = 10_000_000 + totalEnergy;


### PR DESCRIPTION
## Description
### Bug Fix
'ElectricGaugePeripheral' incorrectly calls `scale.getValue()`, which makes Computers getting an incorrect scaled value.
### Energy Meter Scale
Energy Meter now has a scroll input on its back to scale power count.
It wouldn't scale internal count. Instead, it will scale outputs, which is keeps the meaning of internal count.

It's also applied to advancement, because it makes the behavior consistent with the description.