### PR TITLE
Fix state oscillation of HV Switch and Motor Fix

### DIFF
--- a/src/main/java/com/george_vi/electroenergetics/content/electric_motor/ElectricMotorBlockEntity.java
+++ b/src/main/java/com/george_vi/electroenergetics/content/electric_motor/ElectricMotorBlockEntity.java
@@ -289,6 +289,7 @@ public class ElectricMotorBlockEntity extends GeneratingKineticBlockEntity {
     }
 
     float calculateMotorCapacity(double voltage) {
-        return (float) ((voltage * voltage) / CEEConfigs.server().resistanceValues.motorResistance.get());
+        return (float) ((voltage * voltage) / CEEConfigs.server().resistanceValues.motorResistance.get())
+                * CEEConfigs.server().rotorValues.rotorStressMultiplier.getF();
     }
 }

--- a/src/main/java/com/george_vi/electroenergetics/content/transmission_distribution/hv_switch/HVSwitchDevice.java
+++ b/src/main/java/com/george_vi/electroenergetics/content/transmission_distribution/hv_switch/HVSwitchDevice.java
@@ -62,14 +62,6 @@ public class HVSwitchDevice extends SimpleElectricalDevice {
                 state = SwitchState.ARCING;
                 airResistance = Mth.lerp(progress, 200000, 100);
             }
-        } else if (progress > 0.6 && isConnecting)
-            state = SwitchState.MOVING;
-        else if (state == SwitchState.CONNECTED && progress < 0.8 && !isConnecting) {
-            if (current > 0.05) {
-                state = SwitchState.ARCING;
-                airResistance = Mth.lerp(progress, 200000, 100);
-            } else
-                state = SwitchState.DISCONNECTED;
         } else if (state == SwitchState.ARCING) {
             if (!isConnecting) {
                 if (voltage < Mth.lerp(progress, 3000, 1) ||
@@ -78,6 +70,14 @@ public class HVSwitchDevice extends SimpleElectricalDevice {
                 }
             }
             airResistance = Mth.lerp(progress, 200000, 100);
+        } else if (progress > 0.6 && isConnecting)
+            state = SwitchState.MOVING;
+        else if (state == SwitchState.CONNECTED && progress < 0.8 && !isConnecting) {
+            if (current > 0.05) {
+                state = SwitchState.ARCING;
+                airResistance = Mth.lerp(progress, 200000, 100);
+            } else
+                state = SwitchState.DISCONNECTED;
         }
 
         if (state == SwitchState.MOVING)


### PR DESCRIPTION
### Description ###
Fix state oscillation of HV Switch through adjusting if-else priority.
It originally caused that HV Switch's state unreasonably oscillated between ARCING and MOVING when closing HV Switch